### PR TITLE
Adding back security and license info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,11 @@ Finally, to undeploy the controllers:
 ```
 make undeploy 
 ```
+
+## Security
+
+See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+
+## License
+
+This project is licensed under the Apache-2.0 License.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding info removed on https://github.com/aws/zone-aware-controllers-for-k8s/pull/1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
