### PR TITLE
Update e2e tests to use registry.k8s.io images

### DIFF
--- a/e2e/zau/faults_test.go
+++ b/e2e/zau/faults_test.go
@@ -24,7 +24,7 @@ func configurePauseAlarm(ctx context.Context, cfg *envconf.Config, alarmName str
 
 // deployHealthyImage will upgrade the StatefulSet under test to a working container image
 func deployHealthyImage(ctx context.Context, cfg *envconf.Config) error {
-	return deployImage(ctx, cfg, "k8s.gcr.io/nginx-slim:0.8")
+	return deployImage(ctx, cfg, "registry.k8s.io/nginx-slim:0.8")
 }
 
 // deployFaultyImage will upgrade the StatefulSet under test to a container image that will cause a pod failure

--- a/e2e/zau/manifests.go
+++ b/e2e/zau/manifests.go
@@ -35,7 +35,7 @@ spec:
           whenUnsatisfiable: DoNotSchedule
       containers:
         - name: nginx
-          image: k8s.gcr.io/nginx-slim:0.8
+          image: registry.k8s.io/nginx-slim:0.8
           ports:
             - containerPort: 80
               name: web

--- a/e2e/zau/zau_test.go
+++ b/e2e/zau/zau_test.go
@@ -212,7 +212,7 @@ func TestE2EZauOverlappingDeployments(t *testing.T) {
 	f1 := features.New("overlapping deployment").
 		Assess("no disruption breach", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			g := NewWithT(t)
-			upgrades := []string{"k8s.gcr.io/nginx-slim:0.6", "k8s.gcr.io/nginx-slim:0.7", "k8s.gcr.io/nginx-slim:0.8", "k8s.gcr.io/nginx-slim:0.9"}
+			upgrades := []string{"registry.k8s.io/nginx-slim:0.6", "registry.k8s.io/nginx-slim:0.7", "registry.k8s.io/nginx-slim:0.8", "registry.k8s.io/nginx-slim:0.9"}
 
 			for _, upgrade := range upgrades {
 				t.Logf("updated statefulset image to %s", upgrade)

--- a/e2e/zdb/manifests.go
+++ b/e2e/zdb/manifests.go
@@ -38,7 +38,7 @@ spec:
           whenUnsatisfiable: DoNotSchedule
       containers:
         - name: nginx
-          image: k8s.gcr.io/nginx-slim:0.8
+          image: registry.k8s.io/nginx-slim:0.8
           ports:
             - containerPort: 80
               name: e2e-pod


### PR DESCRIPTION
*Description of changes:*
Fixes #17 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
